### PR TITLE
Deleted 'apache:zap' from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ require 'capistrano/apache/systemd'
 * apache:force_reload
 * apache:restart
 * apache:stop
-* apache:zap
 
 You can execute the task on command line:
  


### PR DESCRIPTION
README.md file was referencing a non-existent command 'apache:zap'.